### PR TITLE
Updated MakeAsyncFunction prop types to accept an ActionMatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ Most of the popular React form libraries accept an `onSubmit` function that is e
 
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-* [Usage](#usage)
-  * [Step 1](#step-1)
-  * [Step 2](#step-2)
-* [API](#api)
-  * [`MakeAsyncFunction: React.Component<Props>`](#makeasyncfunction-reactcomponentprops)
-* [Types](#types)
-  * [`Props`](#props)
-    * [`start: string`](#start-string)
-    * [`resolve: string`](#resolve-string)
-    * [`reject: string`](#reject-string)
-    * [`setPayload?: (action: Object, payload: any) => Object`](#setpayload-action-object-payload-any--object)
-    * [`getPayload?: (action: Object) => any`](#getpayload-action-object--any)
-    * [`getError?: (action: Object) => any`](#geterror-action-object--any)
+- [Usage](#usage)
+  - [Step 1](#step-1)
+  - [Step 2](#step-2)
+- [API](#api)
+  - [`MakeAsyncFunction: React.Component<Props>`](#makeasyncfunction-reactcomponentprops)
+- [Types](#types)
+  - [`Props`](#props)
+    - [`start: string`](#start-string)
+    - [`resolve: string | ActionMatcher`](#resolve-string--actionmatcher)
+    - [`reject: string | ActionMatcher`](#reject-string--actionmatcher)
+    - [`setPayload?: (action: Object, payload: any) => Object`](#setpayload-action-object-payload-any--object)
+    - [`getPayload?: (action: Object) => any`](#getpayload-action-object--any)
+    - [`getError?: (action: Object) => any`](#geterror-action-object--any)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2073,12 +2073,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2093,17 +2095,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -2220,7 +2225,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -2232,6 +2238,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -2246,6 +2253,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -2253,12 +2261,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -2277,6 +2287,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -2357,7 +2368,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -2369,6 +2381,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -2490,6 +2503,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -10382,9 +10396,9 @@
       }
     },
     "redux-promise-listener": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/redux-promise-listener/-/redux-promise-listener-1.0.0.tgz",
-      "integrity": "sha512-/LsFprVhKbjHNUO7N40joxS0fGTzp6tLACbXMBblhEfT4dCNCmrb3sRYAqHRDKLE8wHW5DfLr8aCCRf4E5ZFPg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/redux-promise-listener/-/redux-promise-listener-1.1.0.tgz",
+      "integrity": "sha512-sdSVjDPdorGULkcqb+nbNTywWENvthe+1LDMLvFddxD83btlYHZv+8OaYelxD3v5XA1vlPlq26nb5msEOmk/Zw==",
       "dev": true
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-dom": "^16.4.1",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
-    "redux-promise-listener": "^1.0.0",
+    "redux-promise-listener": "^1.1.0",
     "rollup": "^0.63.5",
     "rollup-plugin-babel": "^3.0.7",
     "rollup-plugin-commonjs": "^9.1.4",
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "redux": ">=3.0.0",
-    "redux-promise-listener": ">=1.0.0",
+    "redux-promise-listener": ">=1.1.0",
     "prop-types": "^15.6.0",
     "react": "^15.3.0 || ^16.0.0",
     "react-redux": ">=5.0.0"

--- a/src/MakeAsyncFunction.js
+++ b/src/MakeAsyncFunction.js
@@ -23,8 +23,8 @@ export default class MakeAsyncFunction extends React.Component<Props, State> {
     children: PropTypes.func.isRequired,
     listener: PropTypes.object.isRequired,
     start: PropTypes.string.isRequired,
-    resolve: PropTypes.string.isRequired,
-    reject: PropTypes.string.isRequired,
+    resolve: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
+    reject: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
     setPayload: PropTypes.func,
     getPayload: PropTypes.func,
     getError: PropTypes.func

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,11 +1,15 @@
 // @flow
 import * as React from 'react'
-import type { SetPayload, GetPayload } from 'redux-promise-listener'
+import type {
+  SetPayload,
+  GetPayload,
+  ActionMatcher
+} from 'redux-promise-listener'
 
 type Props = {
   start: string,
-  resolve: string,
-  reject: string,
+  resolve: string | ActionMatcher,
+  reject: string | ActionMatcher,
   setPayload?: SetPayload,
   getPayload?: GetPayload,
   getError?: GetPayload


### PR DESCRIPTION
Hi @erikras 

A few changes on the prop types/flow def/doc to allow an ActionMatcher on `resolve` and `reject` props, without raising a warning (as seen in redux-promise-listener 1.1.0)

Keep up the good work!

Cheers.